### PR TITLE
Verify user account via Email

### DIFF
--- a/src/main/java/org/demo/huyminh/AOP/TokenValidationAspect.java
+++ b/src/main/java/org/demo/huyminh/AOP/TokenValidationAspect.java
@@ -42,15 +42,12 @@ public class TokenValidationAspect {
         }
 
         token = token.substring(7);
-        log.info("Chan lai truoc ca khi vao controller");
-        log.info("Token: {}", token);
 
         try {
             SignedJWT signedJWT = SignedJWT.parse(token);
             String jti = signedJWT.getJWTClaimsSet().getJWTID();
 
             if (invalidateRepository.existsById(jti)) {
-                log.info("TokenID: {}", jti);
                 throw new AppException(ErrorCode.INVALID_TOKEN);
             }
         } catch (ParseException e) {

--- a/src/main/java/org/demo/huyminh/Controller/AuthenticationController.java
+++ b/src/main/java/org/demo/huyminh/Controller/AuthenticationController.java
@@ -3,19 +3,25 @@ package org.demo.huyminh.Controller;
 import com.nimbusds.jose.JOSEException;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
 import org.demo.huyminh.DTO.Reponse.ApiResponse;
 import org.demo.huyminh.DTO.Reponse.LoginResponse;
 import org.demo.huyminh.DTO.Reponse.IntrospectResponse;
-import org.demo.huyminh.DTO.Request.LoginRequest;
-import org.demo.huyminh.DTO.Request.IntrospectRequest;
-import org.demo.huyminh.DTO.Request.LogoutRequest;
-import org.demo.huyminh.DTO.Request.RefreshRequest;
+import org.demo.huyminh.DTO.Reponse.UserResponse;
+import org.demo.huyminh.DTO.Request.*;
+import org.demo.huyminh.Entity.Otp;
+import org.demo.huyminh.Entity.User;
+import org.demo.huyminh.Event.VerificationEmailEvent;
 import org.demo.huyminh.Exception.AppException;
 import org.demo.huyminh.Exception.ErrorCode;
+import org.demo.huyminh.Repository.OptRepository;
+import org.demo.huyminh.Repository.UserRepository;
 import org.demo.huyminh.Service.AuthenticationService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import java.text.ParseException;
+import java.util.Date;
 
 /**
  * @author Minh
@@ -23,6 +29,7 @@ import java.text.ParseException;
  * Time: 1:55 PM
  */
 
+@Slf4j
 @RestController
 @RequestMapping("/api/v1/auth")
 @RequiredArgsConstructor
@@ -30,14 +37,66 @@ import java.text.ParseException;
 public class AuthenticationController {
 
     AuthenticationService authenticationService;
+    ApplicationEventPublisher eventPublisher;
+    OptRepository optRepository;
+    UserRepository userRepository;
+
+    @PostMapping("/register")
+    ApiResponse<UserResponse> register(@RequestBody UserCreationRequest request) {
+        User user = authenticationService.register(request);
+
+        eventPublisher.publishEvent(new VerificationEmailEvent(user));
+
+        return ApiResponse.<UserResponse>builder()
+                .code(HttpStatus.OK.value())
+                .message("Register successfully. Please, verify your email !")
+                .result(UserResponse.builder().id(user.getId()).build())
+                .build();
+    }
+
+    @GetMapping("/verifyEmail")
+     ApiResponse<Void> verifyEmail(@RequestParam("otp") String otp, @RequestParam("userId") String userId) {
+        Otp theOtp = optRepository.findByCode(otp, userId);
+
+        if(theOtp == null) {
+            throw new AppException(ErrorCode.OTP_NOT_EXISTS);
+        }
+        if (theOtp.getExpireTime().before(new Date())) {
+            throw new AppException(ErrorCode.OTP_EXPIRED);
+        }
+
+        User user = theOtp.getUser();
+        user.setEnabled(true);
+        userRepository.save(user);
+        optRepository.delete(theOtp);
+        return ApiResponse.<Void>builder()
+                .code(HttpStatus.OK.value())
+                .message("Email verified successfully. Please, login your new account !")
+                .build();
+    }
+
+    @GetMapping ("/resendVerifyEmail")
+    ApiResponse<Void> resendVerifyEmail(@RequestParam("userId") String userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_EXISTS));
+        if (user.isEnabled()) {
+            throw new AppException(ErrorCode.USER_IS_ENABLED);
+        }
+
+        eventPublisher.publishEvent(new VerificationEmailEvent(user));
+        return ApiResponse.<Void>builder()
+                .code(HttpStatus.OK.value())
+                .message("Email resend successfully. Please, verify your email !")
+                .build();
+    }
 
     @PostMapping("/login")
     ApiResponse<LoginResponse> login(@RequestBody LoginRequest request) {
-        LoginResponse result = null;
+        LoginResponse result;
         try {
             result = authenticationService.authenticate(request);
         } catch (ParseException e) {
-            throw new AppException(ErrorCode.USER_NOT_EXISTS);
+            throw new RuntimeException(e);
         }
 
         return ApiResponse.<LoginResponse>builder()
@@ -47,7 +106,7 @@ public class AuthenticationController {
     }
 
     @PostMapping("/introspect")
-    ApiResponse<IntrospectResponse> login(@RequestBody IntrospectRequest request) throws ParseException, JOSEException {
+    ApiResponse<IntrospectResponse> introspect(@RequestBody IntrospectRequest request) throws ParseException, JOSEException {
         IntrospectResponse result = authenticationService.introspect(request);
 
         return ApiResponse.<IntrospectResponse>builder()

--- a/src/main/java/org/demo/huyminh/Controller/UserController.java
+++ b/src/main/java/org/demo/huyminh/Controller/UserController.java
@@ -28,16 +28,6 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/users")
-    ApiResponse<User> createUser(@RequestBody @Valid UserCreationRequest request) {
-        ApiResponse<User> apiResponse = new ApiResponse<>();
-
-        apiResponse.setResult(userService.createUser(request));
-        apiResponse.setCode(HttpStatus.OK.value());
-        apiResponse.setMessage("User created successfully");
-        return apiResponse;
-    }
-
     @GetMapping("/users")
     ApiResponse<List<UserResponse>> getUsers() {
         //Get user's info when they are logged in

--- a/src/main/java/org/demo/huyminh/DTO/Reponse/UserResponse.java
+++ b/src/main/java/org/demo/huyminh/DTO/Reponse/UserResponse.java
@@ -1,9 +1,7 @@
 package org.demo.huyminh.DTO.Reponse;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
 import lombok.experimental.FieldDefaults;
 import java.time.LocalDate;
 import java.util.Set;
@@ -19,6 +17,7 @@ import java.util.Set;
 @FieldDefaults(level = lombok.AccessLevel.PRIVATE)
 @NoArgsConstructor
 @AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserResponse {
 
     String id;

--- a/src/main/java/org/demo/huyminh/Entity/Otp.java
+++ b/src/main/java/org/demo/huyminh/Entity/Otp.java
@@ -1,0 +1,49 @@
+package org.demo.huyminh.Entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * @author Minh
+ * Date: 9/28/2024
+ * Time: 7:57 PM
+ */
+
+@Entity
+@Builder
+@Getter
+@Setter
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+@NoArgsConstructor
+@AllArgsConstructor
+public class Otp {
+
+    final static int EXPIRATION_TIME = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    int id;
+    String code;
+    Date expireTime;
+
+    @OneToOne
+    @JoinColumn(name = "user_id")
+    User user;
+
+    public Otp(String code, User user) {
+        this.code = code;
+        this.user = user;
+        this.expireTime = generateExpireTime();
+    }
+
+    public Date generateExpireTime() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeInMillis(new Date().getTime());
+        calendar.add(Calendar.MINUTE, EXPIRATION_TIME);
+
+        return new Date(calendar.getTime().getTime());
+    }
+}

--- a/src/main/java/org/demo/huyminh/Entity/User.java
+++ b/src/main/java/org/demo/huyminh/Entity/User.java
@@ -34,6 +34,7 @@ public class User {
     String lastname;
     String email;
     LocalDate dob;
+    boolean isEnabled;
 
     @ManyToMany
     Set<Role> roles;

--- a/src/main/java/org/demo/huyminh/Event/VerificationEmailEvent.java
+++ b/src/main/java/org/demo/huyminh/Event/VerificationEmailEvent.java
@@ -1,0 +1,27 @@
+package org.demo.huyminh.Event;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldDefaults;
+import org.demo.huyminh.Entity.User;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * @author Minh
+ * Date: 9/28/2024
+ * Time: 7:11 PM
+ */
+
+@Getter
+@Setter
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class VerificationEmailEvent extends ApplicationEvent {
+
+    User user;
+
+    public VerificationEmailEvent(User user) {
+        super(user);
+        this.user = user;
+    }
+}

--- a/src/main/java/org/demo/huyminh/Exception/ErrorCode.java
+++ b/src/main/java/org/demo/huyminh/Exception/ErrorCode.java
@@ -25,8 +25,13 @@ public enum ErrorCode {
     INVALID_DOB(HttpStatus.BAD_REQUEST.value(), "Your age must be at least {min}", HttpStatus.BAD_REQUEST),
     DELETE_PERMISSION_FAILED(HttpStatus.BAD_REQUEST.value(), "Delete permission failed", HttpStatus.BAD_REQUEST),
     DELETE_USER_FAILED(HttpStatus.BAD_REQUEST.value(), "Delete user failed", HttpStatus.BAD_REQUEST),
-    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST.value(), "Invalid refresh token", HttpStatus.BAD_REQUEST)
-    ;
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST.value(), "Invalid refresh token", HttpStatus.BAD_REQUEST),
+    EMAIL_PROCESSING_FAILED(HttpStatus.SERVICE_UNAVAILABLE.value(), "Email processing failed", HttpStatus.SERVICE_UNAVAILABLE),
+    USER_NOT_ENABLED(HttpStatus.FORBIDDEN.value(), "User is not enabled", HttpStatus.FORBIDDEN),
+    OTP_NOT_EXISTS(HttpStatus.BAD_REQUEST.value(), "OTP does not exists", HttpStatus.BAD_REQUEST),
+    OTP_EXPIRED(HttpStatus.BAD_REQUEST.value(), "OTP expired", HttpStatus.BAD_REQUEST),
+    USER_IS_DISABLED(HttpStatus.BAD_REQUEST.value(), "Your account is not enabled", HttpStatus.BAD_REQUEST),
+    USER_IS_ENABLED(HttpStatus.BAD_REQUEST.value(), "Your account is enabled", HttpStatus.BAD_REQUEST),;
 
     private int code;
     private String message;

--- a/src/main/java/org/demo/huyminh/Listener/VerificationEmailListener.java
+++ b/src/main/java/org/demo/huyminh/Listener/VerificationEmailListener.java
@@ -1,0 +1,92 @@
+package org.demo.huyminh.Listener;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.demo.huyminh.Entity.Otp;
+import org.demo.huyminh.Entity.User;
+import org.demo.huyminh.Event.VerificationEmailEvent;
+import org.demo.huyminh.Exception.AppException;
+import org.demo.huyminh.Exception.ErrorCode;
+import org.demo.huyminh.Repository.OptRepository;
+import org.springframework.context.ApplicationListener;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+/**
+ * @author Minh
+ * Date: 9/28/2024
+ * Time: 7:19 PM
+ */
+
+@Slf4j
+@EnableAsync
+@Component
+@FieldDefaults(level = lombok. AccessLevel.PRIVATE)
+@RequiredArgsConstructor
+public class VerificationEmailListener implements ApplicationListener<VerificationEmailEvent> {
+
+    final OptRepository optRepository;
+    final JavaMailSender mailSender;
+
+    @Override
+    public void onApplicationEvent(VerificationEmailEvent event) {
+
+        User user = event.getUser();
+
+        String otp = generateOtp();
+        Otp existingOtp = optRepository.findByUserId(user.getId());
+        if(existingOtp != null) {
+            optRepository.save(Otp.builder()
+                    .id(existingOtp.getId())
+                    .expireTime(existingOtp.generateExpireTime())
+                    .user(existingOtp.getUser())
+                    .code(otp)
+                    .build()
+            );
+        } else {
+            optRepository.save(new Otp(otp, user));
+        }
+
+        try {
+            sendVerificationEmail(otp, user);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            throw new AppException(ErrorCode.EMAIL_PROCESSING_FAILED);
+        }
+    }
+
+    public void sendVerificationEmail(String otp, User user) throws MessagingException, UnsupportedEncodingException {
+        String subject = "Email Verification";
+        String senderName = "User Registration Portal Service";
+        String mailContent = "<p> Hi, "+ user.getUsername()+ ", </p>"+
+                "<p>Thank you for registering with us,"+"</p>" +
+                "Please, enter the following OTP to complete your registration.</p>"+
+                 otp +
+                "<p> Thank you <br> Users Registration Portal Service";
+        MimeMessage message = mailSender.createMimeMessage();
+        var messageHelper = new MimeMessageHelper(message);
+        messageHelper.setFrom("auzemon@gmail.com", senderName);
+        messageHelper.setTo(user.getEmail());
+        messageHelper.setSubject(subject);
+        messageHelper.setText(mailContent, true);
+        mailSender.send(message);
+    }
+
+    String generateOtp() {
+        Random random = new Random();
+        int otp = random.nextInt(999999);
+        return String.format("%06d", otp);
+    }
+
+    @Override
+    public boolean supportsAsyncExecution() {
+        return true;
+    }
+}

--- a/src/main/java/org/demo/huyminh/Repository/OptRepository.java
+++ b/src/main/java/org/demo/huyminh/Repository/OptRepository.java
@@ -1,0 +1,20 @@
+package org.demo.huyminh.Repository;
+
+import org.demo.huyminh.Entity.Otp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+/**
+ * @author Minh
+ * Date: 9/28/2024
+ * Time: 8:14 PM
+ */
+
+public interface OptRepository extends JpaRepository<Otp, Integer> {
+
+     @Query("SELECT o FROM Otp o WHERE o.code = ?1 AND o.user.id = ?2")
+     Otp findByCode(String otp, String userId);
+
+     @Query("SELECT o FROM Otp o WHERE o.user.id = ?1")
+     Otp findByUserId(String userId);
+}

--- a/src/main/java/org/demo/huyminh/Repository/UserRepository.java
+++ b/src/main/java/org/demo/huyminh/Repository/UserRepository.java
@@ -2,6 +2,7 @@ package org.demo.huyminh.Repository;
 
 import org.demo.huyminh.Entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -17,4 +18,6 @@ public interface UserRepository extends JpaRepository<User, String> {
     boolean existsByUsername(String username);
 
     Optional<User> findByUsername(String username);
+
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/org/demo/huyminh/SWP391Application.java
+++ b/src/main/java/org/demo/huyminh/SWP391Application.java
@@ -55,6 +55,7 @@ public class SWP391Application {
                     .id(UUID.randomUUID().toString())
                     .email("hoangvo2122@gmail.com")
                     .roles(roles)
+                    .isEnabled(true)
                     .build();
 
             userRepository.save(user);

--- a/src/main/java/org/demo/huyminh/Security/SecurityConfig.java
+++ b/src/main/java/org/demo/huyminh/Security/SecurityConfig.java
@@ -36,11 +36,8 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final String[] SECURED_ENDPOINTS = {};
-    private final String[] UNSECURED_ENDPOINTS = {
-            "/api/v1/auth/login",
-            "/api/v1/auth/introspect",
-            "/api/v1/auth/logout",
-            "/api/v1/auth/refresh",
+    private final String[] UNSECURED_ENDPOINTS = new String[]{
+            "/api/v1/auth/**",
             "/api/v1/users",
     };
 

--- a/src/main/java/org/demo/huyminh/Security/UserRegistrationDetails.java
+++ b/src/main/java/org/demo/huyminh/Security/UserRegistrationDetails.java
@@ -1,0 +1,69 @@
+package org.demo.huyminh.Security;
+
+import org.demo.huyminh.Entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Minh
+ * Date: 9/28/2024
+ * Time: 2:20 PM
+ */
+
+
+public class UserRegistrationDetails implements UserDetails {
+
+    String username;
+    String password;
+    boolean isEnabled;
+    List<GrantedAuthority> authorities;
+
+    public UserRegistrationDetails(User user) {
+        this.username = user.getUsername();
+        this.password = user.getPassword();
+        this.isEnabled = user.isEnabled();
+        this.authorities = user.getRoles().stream()
+                .map(role -> new SimpleGrantedAuthority(role.getName()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+}

--- a/src/main/java/org/demo/huyminh/Security/UserRegistrationDetailsService.java
+++ b/src/main/java/org/demo/huyminh/Security/UserRegistrationDetailsService.java
@@ -1,0 +1,30 @@
+package org.demo.huyminh.Security;
+
+import lombok.RequiredArgsConstructor;
+import org.demo.huyminh.Exception.AppException;
+import org.demo.huyminh.Exception.ErrorCode;
+import org.demo.huyminh.Repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author Minh
+ * Date: 9/28/2024
+ * Time: 11:23 PM
+ */
+
+@Service
+@RequiredArgsConstructor
+public class UserRegistrationDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        return userRepository.findByEmail(email)
+                .map(UserRegistrationDetails::new)
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_EXISTS));
+    }
+}

--- a/src/main/java/org/demo/huyminh/Service/UserService.java
+++ b/src/main/java/org/demo/huyminh/Service/UserService.java
@@ -3,11 +3,8 @@ package org.demo.huyminh.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.demo.huyminh.DTO.Reponse.UserResponse;
-import org.demo.huyminh.DTO.Request.UserCreationRequest;
 import org.demo.huyminh.DTO.Request.UserUpdateRequest;
-import org.demo.huyminh.Entity.Role;
 import org.demo.huyminh.Entity.User;
-import org.demo.huyminh.Enums.Roles;
 import org.demo.huyminh.Exception.AppException;
 import org.demo.huyminh.Exception.ErrorCode;
 import org.demo.huyminh.Mapper.UserMapper;
@@ -38,20 +35,6 @@ public class UserService {
     private final PasswordEncoder encoder;
     private final RoleRepository roleRepository;
 
-    public User createUser(UserCreationRequest request) {
-        if(userRepository.existsByUsername(request.getUsername())) {
-            throw new AppException(ErrorCode.USER_EXISTS);
-        }
-
-        User user = userMapper.toUser(request);
-        user.setPassword(encoder.encode(request.getPassword()));
-
-        HashSet<Role> roles = new HashSet<>();
-        roles.add(Role.builder().name(Roles.USER.name()).build());
-        user.setRoles(roles);
-
-        return userRepository.save(user);
-    }
 
     @PreAuthorize("hasAuthority('APPROVE_POST')")
     public List<UserResponse> getUsers() {


### PR DESCRIPTION
## Description
This pull request integrates the `feature/verifyEmail` branch into the `develop` branch. This feature allows users to verify their email addresses through a token (OTP).

## Key Changes
- Added an endpoint for user registration, sending and resending verification tokens (OTPs) via email.

- Added an endpoint for token verification and activating user accounts.
  
- Implemented checks and handling for cases such as non-existent OTPs and expired OTPs.

## Rationale

This feature is a critical part of the user registration process, enhancing security and account verification.

## Testing Instructions

1. Run the application and register a user via the `/register` API.

2. Check the email to receive the OTP.

3. Verify the OTP through the `/verifyEmail` API.

4. Resend the email via the `/resendVerifyEmail` API.

5. Evaluate various scenarios: invalid OTP, expired OTP, and successful verification.