### PR TITLE
Add resend email and forgot password feature

### DIFF
--- a/src/main/java/org/demo/huyminh/DTO/Request/ForgotPasswordRequest.java
+++ b/src/main/java/org/demo/huyminh/DTO/Request/ForgotPasswordRequest.java
@@ -1,0 +1,23 @@
+package org.demo.huyminh.DTO.Request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * @author Minh
+ * Date: 9/29/2024
+ * Time: 2:39 PM
+ */
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+public class ForgotPasswordRequest {
+
+    String email;
+}

--- a/src/main/java/org/demo/huyminh/DTO/Request/ResendEmailRequest.java
+++ b/src/main/java/org/demo/huyminh/DTO/Request/ResendEmailRequest.java
@@ -1,0 +1,23 @@
+package org.demo.huyminh.DTO.Request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * @author Minh
+ * Date: 9/29/2024
+ * Time: 6:00 PM
+ */
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+public class ResendEmailRequest {
+
+    String userId;
+}

--- a/src/main/java/org/demo/huyminh/DTO/Request/ResetPasswordRequest.java
+++ b/src/main/java/org/demo/huyminh/DTO/Request/ResetPasswordRequest.java
@@ -1,0 +1,24 @@
+package org.demo.huyminh.DTO.Request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * @author Minh
+ * Date: 9/29/2024
+ * Time: 3:29 PM
+ */
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+public class ResetPasswordRequest {
+
+    String userId;
+    String newPassword;
+}

--- a/src/main/java/org/demo/huyminh/DTO/Request/VerifyEmailRequest.java
+++ b/src/main/java/org/demo/huyminh/DTO/Request/VerifyEmailRequest.java
@@ -1,0 +1,24 @@
+package org.demo.huyminh.DTO.Request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+/**
+ * @author Minh
+ * Date: 9/29/2024
+ * Time: 5:30 PM
+ */
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+public class VerifyEmailRequest {
+
+    String otp;
+    String userId;
+}

--- a/src/main/java/org/demo/huyminh/Entity/User.java
+++ b/src/main/java/org/demo/huyminh/Entity/User.java
@@ -7,7 +7,6 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import java.time.LocalDate;
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -35,6 +34,7 @@ public class User {
     String email;
     LocalDate dob;
     boolean isEnabled;
+    boolean isPasswordChangeable;
 
     @ManyToMany
     Set<Role> roles;
@@ -45,5 +45,7 @@ public class User {
         this.firstname = firstname;
         this.lastname = lastname;
         this.dob = dob;
+        this.isEnabled = false;
+        this.isPasswordChangeable = false;
     }
 }

--- a/src/main/java/org/demo/huyminh/Exception/ErrorCode.java
+++ b/src/main/java/org/demo/huyminh/Exception/ErrorCode.java
@@ -28,10 +28,12 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST.value(), "Invalid refresh token", HttpStatus.BAD_REQUEST),
     EMAIL_PROCESSING_FAILED(HttpStatus.SERVICE_UNAVAILABLE.value(), "Email processing failed", HttpStatus.SERVICE_UNAVAILABLE),
     USER_NOT_ENABLED(HttpStatus.FORBIDDEN.value(), "User is not enabled", HttpStatus.FORBIDDEN),
-    OTP_NOT_EXISTS(HttpStatus.BAD_REQUEST.value(), "OTP does not exists", HttpStatus.BAD_REQUEST),
+    OTP_NOT_EXISTS(HttpStatus.BAD_REQUEST.value(), "OTP is not available", HttpStatus.BAD_REQUEST),
     OTP_EXPIRED(HttpStatus.BAD_REQUEST.value(), "OTP expired", HttpStatus.BAD_REQUEST),
     USER_IS_DISABLED(HttpStatus.BAD_REQUEST.value(), "Your account is not enabled", HttpStatus.BAD_REQUEST),
-    USER_IS_ENABLED(HttpStatus.BAD_REQUEST.value(), "Your account is enabled", HttpStatus.BAD_REQUEST),;
+    USER_IS_ENABLED(HttpStatus.BAD_REQUEST.value(), "Your account is enabled", HttpStatus.BAD_REQUEST),
+    OTP_IS_NOT_USED(HttpStatus.BAD_REQUEST.value(), "OTP is not used. You can not change password until you finish verification step.", HttpStatus.BAD_REQUEST),
+    USER_IS_NOT_CHANGEABLE(HttpStatus.FORBIDDEN.value(), "User password is not changeable", HttpStatus.FORBIDDEN);
 
     private int code;
     private String message;

--- a/src/main/java/org/demo/huyminh/Repository/OptRepository.java
+++ b/src/main/java/org/demo/huyminh/Repository/OptRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.jpa.repository.Query;
  */
 
 public interface OptRepository extends JpaRepository<Otp, Integer> {
-
      @Query("SELECT o FROM Otp o WHERE o.code = ?1 AND o.user.id = ?2")
      Otp findByCode(String otp, String userId);
 

--- a/src/main/java/org/demo/huyminh/SWP391Application.java
+++ b/src/main/java/org/demo/huyminh/SWP391Application.java
@@ -56,6 +56,7 @@ public class SWP391Application {
                     .email("hoangvo2122@gmail.com")
                     .roles(roles)
                     .isEnabled(true)
+                    .isPasswordChangeable(false)
                     .build();
 
             userRepository.save(user);

--- a/src/main/java/org/demo/huyminh/Service/AuthenticationService.java
+++ b/src/main/java/org/demo/huyminh/Service/AuthenticationService.java
@@ -80,6 +80,21 @@ public class AuthenticationService {
         return userRepository.save(user);
     }
 
+    public void resetPassword(ResetPasswordRequest request) {
+        User user = userRepository.findById(request.getUserId())
+                .orElseThrow(() -> new AppException(ErrorCode.USER_NOT_EXISTS));
+
+        if (!user.isEnabled()) {
+            throw new AppException(ErrorCode.USER_IS_DISABLED);
+        } else if (!user.isPasswordChangeable()) {
+            throw new AppException(ErrorCode.USER_IS_NOT_CHANGEABLE);
+        }
+
+        user.setPassword(encoder.encode(request.getNewPassword()));
+        user.setPasswordChangeable(false);
+        userRepository.save(user);
+    }
+
     public IntrospectResponse introspect(IntrospectRequest request) throws ParseException, JOSEException {
 
         var token = request.getToken();

--- a/src/main/resources/templates/VerificationEmail.html
+++ b/src/main/resources/templates/VerificationEmail.html
@@ -53,7 +53,7 @@
     <h1>Email Verification</h1>
     <p>Hi <span th:text="${name}"></span>,</p>
     <p>Thank you for registering with us. To complete your registration, please use the following OTP (One-Time Password) to verify your email address:</p>
-    <div class="otp-code" th:text="${otp}"></div>
+    <div class="otp-code" th:text="${otp}">903495</div>
     <p>This OTP will expire in <span th:text="${expirationTime}"></span> minutes.</p>
     <p>If you didn't request this verification, please ignore this email.</p>
     <p>Thank you,<br>User Registration Portal Service</p>


### PR DESCRIPTION
# Pull Request: Merge feature/verifyEmail branch

## Description

This pull request proposes merging the `feature/verifyEmail` branch into the main branch. This branch implements functionalities related to email confirmation and password reset through a coherent workflow, which includes:

1. **Forgot Password**: Users can request a verification link via email.
2. **Verify Email**: Users confirm their email address using an OTP code.
3. **Reset Password**: Users can reset their password after verifying their email.

## Key Features

### 1. Forgot Password
- **Endpoint**: `/forgotPassword`
- **Method**: POST
- **Description**: Users request an email to reset their password.
- **Request**:
    ```json
    {
        "email": "example@example.com"
    }
    ```
- **Response**:
    - Success: Email sent successfully; please verify your email to change your password.

### 2. Verify Email
- **Endpoint**: `/verifyEmail`
- **Method**: POST
- **Description**: Validates the OTP sent to the user's email.
- **Request**:
    ```json
    {
        "otp": "123456",
        "userId": "user-id-123"
    }
    ```
- **Response**:
    - Success: Email verified, user account enabled if necessary, and prompts password change if not previously set.

### 3. Reset Password
- **Endpoint**: `/resetPassword`
- **Method**: POST
- **Description**: Allows the user to reset their password after email verification.
- **Request**:
    ```json
    {
        "userId": "user-id-123",
        "newPassword": "newStrongPassword"
    }
    ```
- **Response**:
    - Success: Password changed successfully.

## Testing Instructions

1. Send a request to `/forgotPassword` with the user's email.
2. Receive the OTP and send a request to `/verifyEmail` with the OTP and user ID.
3. Make a request to `/resetPassword` to set a new password.